### PR TITLE
Refactor embed_images macro syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,10 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 name = "escpos-embed-image"
 version = "0.1.0"
 dependencies = [
+ "glob",
+ "heck 0.4.1",
  "image",
+ "proc-macro2",
  "quote",
  "syn",
 ]
@@ -305,6 +308,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "half"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +328,12 @@ name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -836,7 +851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
 dependencies = [
  "cfg-expr",
- "heck",
+ "heck 0.5.0",
  "pkg-config",
  "toml",
  "version-compare",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ proc-macro = true
 image = "0.25"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
+glob = "0.3"
+heck = "0.4"
+proc-macro2 = "1.0"
 
 [dev-dependencies]
 # To allow tests; we might not need, but for demonstration

--- a/README.md
+++ b/README.md
@@ -15,9 +15,18 @@ Designed as a companion to `escpos-embedded`, this crate processes Images at com
 
 ```rust
 use escpos_embedded::Image;
-use escpos_embed_image::embed_image;
+use escpos_embed_image::{embed_image, embed_images};
 
 static LOGO: Image<'static> = embed_image!("assets/logo.png");
+
+embed_images!(
+    enum Assets {
+        #[pattern("assets/*.png")]
+    }
+);
+
+// Generated enum `Assets` with variants for each matched file
+// Assets::Logo.get_image() -> &'static Image
 ```
 
 ## How it works

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,12 @@
+use glob::glob;
+use heck::{ToShoutySnakeCase, ToUpperCamelCase};
 use proc_macro::TokenStream;
+use proc_macro2::Span;
 use quote::quote;
+use std::collections::HashSet;
 use std::env;
 use std::path::PathBuf;
-use syn::LitStr;
+use syn::{parse::Parse, parse::ParseStream, Attribute, Ident, LitStr, Token};
 
 #[proc_macro]
 pub fn embed_image(input: TokenStream) -> TokenStream {
@@ -51,5 +55,93 @@ pub fn embed_image(input: TokenStream) -> TokenStream {
             data: DATA,
         }
     }};
+    out.into()
+}
+
+struct EmbedImagesInput {
+    enum_ident: Ident,
+    patterns: Vec<LitStr>,
+}
+
+impl Parse for EmbedImagesInput {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        input.parse::<Token![enum]>()?;
+        let enum_ident: Ident = input.parse()?;
+        let content;
+        syn::braced!(content in input);
+        let attrs: Vec<Attribute> = content.call(Attribute::parse_outer)?;
+        if !content.is_empty() {
+            return Err(content.error("unexpected tokens inside enum"));
+        }
+        let mut patterns = Vec::new();
+        for attr in attrs {
+            if attr.path().is_ident("pattern") {
+                let lit: LitStr = attr.parse_args()?;
+                patterns.push(lit);
+            } else {
+                return Err(syn::Error::new_spanned(attr, "unsupported attribute"));
+            }
+        }
+        Ok(EmbedImagesInput {
+            enum_ident,
+            patterns,
+        })
+    }
+}
+
+#[proc_macro]
+pub fn embed_images(input: TokenStream) -> TokenStream {
+    let EmbedImagesInput {
+        enum_ident,
+        patterns,
+    } = syn::parse_macro_input!(input as EmbedImagesInput);
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+
+    let mut seen = HashSet::new();
+    let mut variants = Vec::new();
+    let mut consts = Vec::new();
+    let mut arms = Vec::new();
+
+    for pattern in patterns {
+        let full_pattern: PathBuf = PathBuf::from(&manifest_dir).join(pattern.value());
+        for entry in
+            glob(full_pattern.to_str().expect("invalid pattern")).expect("failed to read glob")
+        {
+            let path = entry.expect("glob path error");
+            let file_stem = path.file_stem().expect("no file name").to_string_lossy();
+            let variant_name = file_stem.to_upper_camel_case();
+            if !seen.insert(variant_name.clone()) {
+                continue;
+            }
+            let variant_ident = syn::Ident::new(&variant_name, Span::call_site());
+            let const_ident = syn::Ident::new(&file_stem.to_shouty_snake_case(), Span::call_site());
+
+            let rel_path = path.strip_prefix(&manifest_dir).unwrap_or(&path);
+            let rel_path_str = rel_path.to_string_lossy();
+
+            consts.push(quote! {
+                static #const_ident: escpos_embedded::Image<'static> = embed_image!(#rel_path_str);
+            });
+            variants.push(quote! { #variant_ident });
+            arms.push(quote! { #enum_ident::#variant_ident => &#const_ident });
+        }
+    }
+
+    let out = quote! {
+        #(#consts)*
+
+        pub enum #enum_ident {
+            #(#variants),*
+        }
+
+        impl #enum_ident {
+            pub fn get_image(&self) -> &'static escpos_embedded::Image<'static> {
+                match self {
+                    #(#arms),*
+                }
+            }
+        }
+    };
+
     out.into()
 }


### PR DESCRIPTION
## Summary
- allow multiple glob patterns via new `embed_images!` syntax
- update README example to show new enum-style usage

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68855dea254c8331a61bf98086777ba5