### PR TITLE
Make get_image const

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ pub fn embed_images(input: TokenStream) -> TokenStream {
         }
 
         impl #enum_ident {
-            pub fn get_image(&self) -> &'static escpos_embedded::Image<'static> {
+            pub const fn get_image(&self) -> &'static escpos_embedded::Image<'static> {
                 match self {
                     #(#arms),*
                 }


### PR DESCRIPTION
## Summary
- allow match expression in `embed_images!`-generated `get_image()` to be used in const contexts

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_688562a413848331b7c8abc4ac71ea32