### PR TITLE
Update macros for generic Image type

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 A procedural macro for embedding monochrome, dithered images into ESC/POS printer drivers at compile time.
 
-Designed as a companion to `escpos-embedded`, this crate processes Images at compile time and generates a static `Image<'static>` compatible with the `no_std`, allocation-free printer interface.
+Designed as a companion to `escpos-embedded`, this crate processes Images at compile time and generates a static `Image<&'static [u8]>` compatible with the `no_std`, allocation-free printer interface.
 
 ## Features
 
 - Compile-time image loading and conversion
 - Converts image file to 1-bit dithered format (Bi-level Floyd-Steinberg)
-- Outputs `Image<'static>` struct ready for printing
+- Outputs `Image<&'static [u8]>` struct ready for printing
 - No runtime dependencies
 
 ## Example
@@ -17,7 +17,7 @@ Designed as a companion to `escpos-embedded`, this crate processes Images at com
 use escpos_embedded::Image;
 use escpos_embed_image::{embed_image, embed_images};
 
-static LOGO: Image<'static> = embed_image!("assets/logo.png");
+static LOGO: Image<&'static [u8]> = embed_image!("assets/logo.png");
 
 embed_images!(
     enum Assets {
@@ -26,7 +26,7 @@ embed_images!(
 );
 
 // Generated enum `Assets` with variants for each matched file
-// Assets::Logo.get_image() -> &'static Image
+// Assets::Logo.get_image() -> &'static Image<&'static [u8]>
 ```
 
 ## How it works

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ pub fn embed_images(input: TokenStream) -> TokenStream {
             let rel_path_str = rel_path.to_string_lossy();
 
             consts.push(quote! {
-                static #const_ident: escpos_embedded::Image<'static> = embed_image!(#rel_path_str);
+                static #const_ident: escpos_embedded::Image<&'static [u8]> = embed_image!(#rel_path_str);
             });
             variants.push(quote! { #variant_ident });
             arms.push(quote! { #enum_ident::#variant_ident => &#const_ident });
@@ -135,7 +135,7 @@ pub fn embed_images(input: TokenStream) -> TokenStream {
         }
 
         impl #enum_ident {
-            pub const fn get_image(&self) -> &'static escpos_embedded::Image<'static> {
+            pub const fn get_image(&self) -> &'static escpos_embedded::Image<&'static [u8]> {
                 match self {
                     #(#arms),*
                 }


### PR DESCRIPTION
## Summary
- update README for new `Image` type
- adjust macros to use `Image<&'static [u8]>`

## Testing
- `cargo check`
- `cargo test --no-run`


------
https://chatgpt.com/codex/tasks/task_e_688577570cd08331936fa8e01fdd1db4